### PR TITLE
Ensure prereq migrations run first

### DIFF
--- a/home/migrations/0002_create_homepage.py
+++ b/home/migrations/0002_create_homepage.py
@@ -49,6 +49,10 @@ def remove_homepage(apps, schema_editor):
 
 class Migration(migrations.Migration):
 
+    run_before = [
+        ('wagtailcore', '0053_locale_model'),
+    ]
+
     dependencies = [
         ('home', '0001_initial'),
     ]


### PR DESCRIPTION
Fixes the migrations so that they can run from scratch.
Something about the upgrade or this change means that the migrations no longer work for my version of sqlite. I'd appreciate if you could pull the branch and test with your version