### PR TITLE
Add template tag to get sections for site

### DIFF
--- a/articles/templatetags/article_tags.py
+++ b/articles/templatetags/article_tags.py
@@ -1,5 +1,5 @@
 from django import template
-from articles.models import FooterPage, ArticlePage
+from articles.models import FooterPage, ArticlePage, SectionPage
 from wagtail.core.models import Site, Page
 
 register = template.Library()
@@ -16,6 +16,16 @@ def footer_pages(context):
         "request": request,
         "footers": pages,
     }
+
+
+@register.simple_tag(takes_context=True)
+def section_pages(context):
+    request = context["request"]
+    pages = []
+    site = Site.find_for_request(request)
+    if site:
+        pages = SectionPage.objects.descendant_of(site.root_page)
+    return pages
 
 
 @register.inclusion_tag("articles/tags/breadcrumbs.html", takes_context=True)

--- a/articles/tests.py
+++ b/articles/tests.py
@@ -4,7 +4,7 @@ from articles.models import SectionPage, SectionIndexPage, ArticlePage
 from wagtail.core.models import Site
 from django.contrib.contenttypes.models import ContentType
 from wagtail.core.models import Page
-from .templatetags.article_tags import get_next_article, breadcrumbs
+from .templatetags.article_tags import get_next_article, breadcrumbs, section_pages
 
 
 class ArticlesTestCaseMixin(object):
@@ -79,3 +79,12 @@ class TestTemplateTags(TestCase, ArticlesTestCaseMixin):
         self.article3.save_revision().publish()
         # it should return article 3
         self.assertEquals(get_next_article(context, self.article).pk, self.article3.pk)
+
+    def test_section_pages(self):
+        request = self.factory.get(self.article.url)
+        context = {"locale_code": "en", "request": request, "self": self.article}
+        sections = section_pages(context)
+        # it should only return 2
+        self.assertEquals(sections.count(), 1)
+        # it should not include section index page
+        self.assertEqual("section1", sections[0].title)

--- a/profiles/templates/profiles/register.html
+++ b/profiles/templates/profiles/register.html
@@ -1,11 +1,16 @@
 {% extends "base.html" %}
-{% load i18n static wagtailsettings_tags wagtailcore_tags %}
+{% load i18n static wagtailsettings_tags wagtailcore_tags article_tags %}
 {% get_settings %}
 
 {% block content %}
   <div class="heading">
     <h1 class="heading__profiles">{% trans "Register" %}</h1>
   </div>
+
+  {% section_pages as sections %}
+  {% for section in sections %}
+    <p>{{section.title}}</p>
+  {% endfor %}
 
   <div class="call-to-action call-to-action--profile">
       <h4 class="heading heading--subtitle">


### PR DESCRIPTION
This is required so that a consistent section listing can be shown throughout the site.