### PR TITLE
Example for how to get site settings in template (Don't merge)

### DIFF
--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags article_tags static theme_tags %}
+{% load wagtailsettings_tags wagtailcore_tags article_tags static theme_tags %}
+{% get_settings %}
 
 
 {% block content %}
+    {{ settings.home.SiteSettings.facebook_sharing }}
     {% comment %}
         <!--
             Ideally should be {% include THEME_PATH|add:"header.html" %} but this does not work.


### PR DESCRIPTION
@Mitso I made this quick PR to provide an example of how things like the google tag manager or other site settings can be used in the templates.
If you need any of the site settings in inherited templates let me know so I can put them in a context processor instead