### PR TITLE
Feature/add theme context processor

### DIFF
--- a/geweb/settings/base.py
+++ b/geweb/settings/base.py
@@ -99,6 +99,7 @@ TEMPLATES = [
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
+                "home.context_processors.get_theme",
                 "django.template.context_processors.debug",
                 "django.template.context_processors.request",
                 "django.template.context_processors.i18n",

--- a/home/context_processors.py
+++ b/home/context_processors.py
@@ -2,6 +2,4 @@ from home.utils import get_theme_from_request
 
 
 def get_theme(request):
-    return {
-        'theme': get_theme_from_request(request)
-    }
+    return {"theme": get_theme_from_request(request)}

--- a/home/context_processors.py
+++ b/home/context_processors.py
@@ -1,0 +1,7 @@
+from home.utils import get_theme_from_request
+
+
+def get_theme(request):
+    return {
+        'theme': get_theme_from_request(request)
+    }

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags article_tags static theme_tags %}
+{% load wagtailcore_tags article_tags static %}
 
 
 {% block content %}
@@ -8,7 +8,6 @@
             Ideally should be {% include THEME_PATH|add:"header.html" %} but this does not work.
         -->
     {% endcomment %}
-    {% get_current_theme as theme %}
     {% if theme.slug == 'ninyampinga' %}
         {% include "./ninyampinga/home.html" %}
     {% elif theme.slug == 'springster' %}

--- a/home/templatetags/theme_tags.py
+++ b/home/templatetags/theme_tags.py
@@ -1,8 +1,6 @@
 from django import template
-from wagtail.core.models import Site
 
-from home.themes import DEFAULT_THEME
-from home.utils import get_theme_from_slug
+from home.utils import get_theme_from_request
 
 register = template.Library()
 
@@ -14,9 +12,4 @@ def get_current_theme(context):
     the site root).
     """
     request = context["request"]
-    site = Site.find_for_request(request)
-    theme = DEFAULT_THEME
-    if site:
-        if site.root_page.specific.theme:
-            theme = get_theme_from_slug(site.root_page.specific.theme)
-    return theme
+    return get_theme_from_request(request)

--- a/home/templatetags/theme_tags.py
+++ b/home/templatetags/theme_tags.py
@@ -1,7 +1,8 @@
 from django import template
 from wagtail.core.models import Site
 
-from home.themes import DEFAULT_THEME, THEMES
+from home.themes import DEFAULT_THEME
+from home.utils import get_theme_from_slug
 
 register = template.Library()
 
@@ -19,16 +20,3 @@ def get_current_theme(context):
         if site.root_page.specific.theme:
             theme = get_theme_from_slug(site.root_page.specific.theme)
     return theme
-
-
-def get_theme_from_slug(value):
-    """
-    Returns the ``Theme`` instance from ``themes.THEMES``
-    with a ``slug`` value matching the provided string.
-    """
-    if not value:
-        return
-    for theme in THEMES:
-        if theme.slug == value:
-            return theme
-    raise ValueError(f"No Theme can be found matching the slug '{value}'.")

--- a/home/utils.py
+++ b/home/utils.py
@@ -1,0 +1,14 @@
+from home.themes import THEMES
+
+
+def get_theme_from_slug(value):
+    """
+    Returns the ``Theme`` instance from ``themes.THEMES``
+    with a ``slug`` value matching the provided string.
+    """
+    if not value:
+        return
+    for theme in THEMES:
+        if theme.slug == value:
+            return theme
+    raise ValueError(f"No Theme can be found matching the slug '{value}'.")

--- a/home/utils.py
+++ b/home/utils.py
@@ -1,4 +1,5 @@
 from wagtail.core.models import Site
+
 from home.themes import DEFAULT_THEME, THEMES
 
 
@@ -12,6 +13,7 @@ def get_theme_from_request(request):
         if site.root_page.specific.theme:
             theme = get_theme_from_slug(site.root_page.specific.theme)
     return theme
+
 
 def get_theme_from_slug(value):
     """

--- a/home/utils.py
+++ b/home/utils.py
@@ -1,5 +1,17 @@
-from home.themes import THEMES
+from wagtail.core.models import Site
+from home.themes import DEFAULT_THEME, THEMES
 
+
+def get_theme_from_request(request):
+    """
+    Returns the Theme object for the current request.
+    """
+    site = Site.find_for_request(request)
+    theme = DEFAULT_THEME
+    if site:
+        if site.root_page.specific.theme:
+            theme = get_theme_from_slug(site.root_page.specific.theme)
+    return theme
 
 def get_theme_from_slug(value):
     """


### PR DESCRIPTION
This moves the functionality that gets the theme for a site into a utils file so it is more general.
Then we also add a context processor that returns which theme has been set on the homepage for a site.
The variable can be accessed from any template using `{{ theme }}`