### PR TITLE
add sentry and fix zathu

### DIFF
--- a/geweb/settings/base.py
+++ b/geweb/settings/base.py
@@ -15,6 +15,9 @@ import os
 
 import environ
 
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+
 env = environ.Env()
 
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -228,3 +231,13 @@ if AWS_STORAGE_BUCKET_NAME and AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
     INSTALLED_APPS += [
         "storages",
     ]
+
+SENTRY_DSN = os.environ.get("SENTRY_DSN", os.environ.get("RAVEN_DSN", ""))
+
+if SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[DjangoIntegration()],
+        send_default_pii=True,
+        traces_sample_rate=float(os.environ.get("SENTRY_TRACES_SAMPLE_RATE", 0.0)),
+    )

--- a/geweb/settings/base.py
+++ b/geweb/settings/base.py
@@ -14,7 +14,6 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 import os
 
 import environ
-
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 

--- a/home/models.py
+++ b/home/models.py
@@ -7,7 +7,7 @@ from wagtail.core.models import Page
 from wagtail.images.blocks import ImageChooserBlock
 from wagtail.images.edit_handlers import ImageChooserPanel
 
-from articles.models import ArticlePage, SectionPage, SectionIndexPage
+from articles.models import ArticlePage, SectionIndexPage, SectionPage
 from forms.models import FormPage
 from home.themes import THEME_CHOICES
 

--- a/home/models.py
+++ b/home/models.py
@@ -7,7 +7,7 @@ from wagtail.core.models import Page
 from wagtail.images.blocks import ImageChooserBlock
 from wagtail.images.edit_handlers import ImageChooserPanel
 
-from articles.models import ArticlePage, SectionPage
+from articles.models import ArticlePage, SectionPage, SectionIndexPage
 from forms.models import FormPage
 from home.themes import THEME_CHOICES
 
@@ -49,7 +49,7 @@ class HomePage(Page):
         context["forms"] = forms
 
         # Ninyampinga featured in homepage adjustment
-        section_index = self.get_children().live().first()
+        section_index = SectionIndexPage.objects.descendant_of(self).live().first()
         context["section_index"] = section_index
 
         articlepages = ArticlePage.objects.live().descendant_of(section_index)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ wagtailfontawesome
 boto3
 django-storages
 wagtailmedia
+sentry-sdk


### PR DESCRIPTION
Zathu is broken because the first child of the Homepage isn't a section index page. This ensures that we're only looking for SectionIndexPages when building the context for the homepage

Also add sentry