### PR TITLE
add support for the django_storages_url

### DIFF
--- a/geweb/settings/base.py
+++ b/geweb/settings/base.py
@@ -18,6 +18,7 @@ import environ
 import sentry_sdk
 from django.conf import global_settings, locale
 from sentry_sdk.integrations.django import DjangoIntegration
+from django_storage_url import dsn_configured_storage_class
 
 env = environ.Env()
 
@@ -245,7 +246,19 @@ AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
 AWS_S3_CUSTOM_DOMAIN = "%s.s3.amazonaws.com" % AWS_STORAGE_BUCKET_NAME
 AWS_DEFAULT_ACL = "public-read"
 
-if AWS_STORAGE_BUCKET_NAME and AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
+# DEFAULT_FILE_STORAGE is configured using DEFAULT_STORAGE_DSN
+DEFAULT_STORAGE_DSN = os.environ.get('DEFAULT_STORAGE_DSN', '')
+
+if DEFAULT_STORAGE_DSN:
+    # dsn_configured_storage_class() requires the name of the setting
+    DefaultStorageClass = dsn_configured_storage_class('DEFAULT_STORAGE_DSN')
+
+    # Django's DEFAULT_FILE_STORAGE requires the class name
+    DEFAULT_FILE_STORAGE = 'geweb.settings.base.DefaultStorageClass'
+    INSTALLED_APPS += [
+        "storages",
+    ]
+elif AWS_STORAGE_BUCKET_NAME and AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
     MEDIA_URL = "https://%s/" % AWS_S3_CUSTOM_DOMAIN
     DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
     INSTALLED_APPS += [

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ boto3
 django-storages
 wagtailmedia
 sentry-sdk
+django_storage_url


### PR DESCRIPTION
Divio provides the details for the s3 storage bucket as the DEFAULT_STORAGE_DSN env var. This library configures the storage class from that env var.