### PR TITLE
Rewrite auth_allowed to not use settings for social auth whitelist

### DIFF
--- a/geweb/pipeline/set_permissions.py
+++ b/geweb/pipeline/set_permissions.py
@@ -14,20 +14,13 @@ def set_permissions(user, is_new, *args, **kwargs):
 
 
 def auth_allowed(user, backend, details, response, request, *args, **kwargs):
-    _update_auth_whitelisted_emails(request)
-    if (
-        not backend.auth_allowed(response, details)
-        or not settings.SOCIAL_AUTH_WHITELISTED_EMAILS
-    ):
-        user.delete()
-        raise AuthForbidden(backend)
-
-
-def _update_auth_whitelisted_emails(request):
     site = Site.find_for_request(request)
     site_settings = SiteSettings.for_site(site)
-    settings.SOCIAL_AUTH_WHITELISTED_EMAILS += [
-        str(email)
-        for email in site_settings.allowed_emails.__iter__()
-        if str(email) not in settings.SOCIAL_AUTH_WHITELISTED_EMAILS
-    ]
+
+    allowed_emails = [email.lower() for email in site_settings.allowed_emails.__iter__()]
+    email = details.get('email')
+    allowed = False
+    if email and allowed_emails:
+        email = email.lower()
+        allowed = email in allowed_emails
+    return allowed


### PR DESCRIPTION
We shouldn't edit the Django settings after startup.
This removes the expectation that the whitelist of emails lives in the Django settings and rather puts it in the SiteSettings